### PR TITLE
Linux git-lfs instructions used brew

### DIFF
--- a/docs/4-running-iost-node/Environment-Configuration.md
+++ b/docs/4-running-iost-node/Environment-Configuration.md
@@ -47,7 +47,9 @@ make test
 ### Installing git-lfs
 
 ```
-brew install git-lfs
+sudo apt-get install software-properties-common curl
+sudo curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt-get install git-lfs
 git lfs install
 ```
 


### PR DESCRIPTION
The Linux instructions for installing "git lfs" used brew, which may be fine, but apt is used throughout the install instructions and brew is not.  Also, apt is native to the OS and brew is not.  So, I pulled the instructions from github and replaced brew (https://github.com/git-lfs/git-lfs/wiki/Installation).  

It is my opinion that dependencies should be very easy to install so developers spend their time writing code with IOST, not wrestling with the development environment.

Tested on a fresh install of Ubuntu 16.04LTS and 18.04LTS.